### PR TITLE
Fix editor breaking when entering play mode

### DIFF
--- a/Packages/enitimeago.non-destructive-mmd/Editor/CommonChecks.cs
+++ b/Packages/enitimeago.non-destructive-mmd/Editor/CommonChecks.cs
@@ -84,13 +84,16 @@ namespace enitimeago.NonDestructiveMMD
                 return false;
             }
 
-            for (int i = 0; i < visemeSkinnedMesh.sharedMesh.blendShapeCount; i++)
+            if (!EditorApplication.isPlaying)
             {
-                string blendShapeName = visemeSkinnedMesh.sharedMesh.GetBlendShapeName(i);
-                if (MmdBlendShapeNames.All.Any(blendShape => blendShape.Name == blendShapeName))
+                for (int i = 0; i < visemeSkinnedMesh.sharedMesh.blendShapeCount; i++)
                 {
-                    LogLocalized("CommonChecks:AvatarFaceSMRExistingBlendShapesUnsupported", Severity.Warning);
-                    return false;
+                    string blendShapeName = visemeSkinnedMesh.sharedMesh.GetBlendShapeName(i);
+                    if (MmdBlendShapeNames.All.Any(blendShape => blendShape.Name == blendShapeName))
+                    {
+                        LogLocalized("CommonChecks:AvatarFaceSMRExistingBlendShapesUnsupported", Severity.Warning);
+                        return false;
+                    }
                 }
             }
 

--- a/Packages/enitimeago.non-destructive-mmd/Localization/en-US.po
+++ b/Packages/enitimeago.non-destructive-mmd/Localization/en-US.po
@@ -47,6 +47,9 @@ msgstr "Select a MMD morph"
 msgid "MappingsEditorWindow:EditingBlendShapesFor"
 msgstr "Editing blendshapes for \"{0}\"..."
 
+msgid "MappingsEditorWindow:ViewingBlendShapesForInPlayMode"
+msgstr "Viewing blendshapes for \"{0}\" (exit play mode to edit)..."
+
 msgid "MappingsEditorWindow:SelectedBlendShapes"
 msgstr "Selected blendshapes"
 
@@ -61,9 +64,6 @@ msgstr "Enable compute shader"
 
 msgid "MappingsEditorWindow:ThumbnailSize"
 msgstr "Thumbnail size"
-
-msgid "MappingsEditorWindow:NoData"
-msgstr "No data. Maybe you are in play mode?"
 
 msgid "SaveFilePanel:SaveUnitypackage"
 msgstr "Save .unitypackage"

--- a/Packages/enitimeago.non-destructive-mmd/Localization/ja-JP.po
+++ b/Packages/enitimeago.non-destructive-mmd/Localization/ja-JP.po
@@ -47,6 +47,9 @@ msgstr "MMDモーフを選んでください"
 msgid "MappingsEditorWindow:EditingBlendShapesFor"
 msgstr "「{0}」のブレンドシェイプを編集中…"
 
+msgid "MappingsEditorWindow:ViewingBlendShapesForInPlayMode"
+msgstr "「{0}」のブレンドシェイプを表示中 (編集するには再生モードを終了してください)…"
+
 msgid "MappingsEditorWindow:SelectedBlendShapes"
 msgstr "選択されているブレンドシェイプ"
 
@@ -61,9 +64,6 @@ msgstr "コンピュートシェーダーを有効にする"
 
 msgid "MappingsEditorWindow:ThumbnailSize"
 msgstr "サムネイルサイズ"
-
-msgid "MappingsEditorWindow:NoData"
-msgstr "データがない。プレイモードに入ったかもしれません。"
 
 msgid "SaveFilePanel:SaveUnitypackage"
 msgstr ".unitypackageで保存"


### PR DESCRIPTION
The EditorWindow is effectively reloaded when entering/leaving play mode, so we need to pull in data again.

Currently we just have a hack that detects if the reference to the blend shape mappings component turns into null and stop rendering the window. But this persists, so the user has to reload the window.

To make things easier on ourselves don't allow editing when in play mode, instead enter a read-only mode.

See #32 for context

Fixes #32