### PR TITLE
Execute passes after Modular Avatar for FaceEmo compatibility

### DIFF
--- a/Packages/enitimeago.non-destructive-mmd/Editor/NonDestructiveMmdPlugin.cs
+++ b/Packages/enitimeago.non-destructive-mmd/Editor/NonDestructiveMmdPlugin.cs
@@ -13,6 +13,7 @@ namespace enitimeago.NonDestructiveMMD
         protected override void Configure()
         {
             var seq = InPhase(BuildPhase.Transforming);
+            seq.AfterPlugin("nadena.dev.modular-avatar");
             seq.Run(BlendShapeMappingsPass.Instance);
             seq.WithRequiredExtension(typeof(AnimationServicesContext), _ =>
             {


### PR DESCRIPTION
Currently Rename Face For MMD can't work for MA Merge Animator's animations because they might not be merged yet to FX when building the avatar. By this patch, the plugin always execute passes after Modular Avatar and works for a merged animator controller. As a result, this makes better compatibility with FaceEmo.